### PR TITLE
fix: cart disappears on refresh

### DIFF
--- a/backend/src/controllers/cartController.js
+++ b/backend/src/controllers/cartController.js
@@ -29,6 +29,26 @@ class cartController {
             next(error);
         }
     }
+    static async getCart(req, res, next) {
+        console.log('========== Getting guest cart ==========');
+        try {
+            const cart = await Cart.findOne({
+                where: { id: req.params.id },
+                include: {
+                    model: Cart_item,
+                },
+            });
+
+            if (cart) {
+                console.log('========== Cart found');
+                res.status(200).json({ cart });
+            } else {
+                res.sendStatus(404);
+            }
+        } catch (error) {
+            next(error);
+        }
+    }
     static async getCartByUserId(req, res, next) {
         console.log('========== Getting cart by user id ==========');
         const UserId = req.params.id;

--- a/backend/src/routes/cart.js
+++ b/backend/src/routes/cart.js
@@ -4,6 +4,7 @@ const checkRole = require('../middlewares/cart/checkRole');
 const cartRouter = Router();
 
 cartRouter.post('/carts', checkRole(), cartController.createCart);
+cartRouter.get('/carts/:id', checkRole(), cartController.getCartByUserId);
 cartRouter.get('/carts/user/:id', checkRole(), cartController.getCartByUserId);
 cartRouter.put('/carts/', checkRole(), cartController.updateCart);
 cartRouter.patch('/carts/', checkRole(), cartController.updateCartUser);

--- a/frontend/src/components/cart/CartModal.vue
+++ b/frontend/src/components/cart/CartModal.vue
@@ -17,20 +17,31 @@
 </template>
 <script setup lang="ts">
 import { useCartStore } from "@/stores/cart.ts";
-import { onUnmounted } from "vue";
+import { onMounted, onUnmounted } from "vue";
 import cartContent from "@/components/cart/CartContent.vue";
-import {useRouter} from "vue-router";
+import { useRouter } from "vue-router";
+import { useUserStore } from "@/stores/user.ts";
 
 const router = useRouter();
+const emits = defineEmits(["close"]);
+const cart = useCartStore();
+const userStore = useUserStore();
 
+onMounted(() => {
+  if(cart.cartItems.length === 0) {
+    if(localStorage.getItem('cartId')) {
+      cart.getGuestCartItems(localStorage.getItem('cartId') as string);
+    } else if (!!userStore.user.id) {
+      cart.mergeOrLinkCart();
+    }
+  }
+})
 onUnmounted(() => {
   emits("close");
 });
 const props = defineProps({
   show: Boolean,
 });
-const emits = defineEmits(["close"]);
-const cart = useCartStore();
 
 function handleClose() {
   emits("close")

--- a/frontend/src/composables/api/useCart.ts
+++ b/frontend/src/composables/api/useCart.ts
@@ -3,6 +3,20 @@ import {CartItem} from "@/dto/cart.dto.ts";
 const baseUrl = import.meta.env.VITE_APP_API_URL;
 
 export const useCart = () => {
+    const getCart = async (id: string) => {
+        const token = localStorage.getItem('auth_token');
+        if (token === null) {
+            return await fetch(baseUrl + Api.cart + `/${id}`, {
+                method: "GET",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+            } ).then(res => res);
+        } else {
+            throw new Error('Error while getting cart');
+        }
+
+    }
     const getCartByUserId = async (id: string) => {
         const token = localStorage.getItem('auth_token');
         if (token === null) {
@@ -86,5 +100,5 @@ export const useCart = () => {
             headers,
         }).then(res => res);
     }
-    return {  getCartByUserId, createCart,createCartNoUser, updateCartUser, updateCartWithProduct, deleteCart };
+    return {  getCart, getCartByUserId, createCart,createCartNoUser, updateCartUser, updateCartWithProduct, deleteCart };
 }

--- a/frontend/src/stores/cart.ts
+++ b/frontend/src/stores/cart.ts
@@ -6,6 +6,7 @@ import { useCart } from "@/composables/api/useCart.ts";
 import {CartItemResponse} from "@/dto/api/cartItem.dto.ts";
 
 const {
+  getCart,
   getCartByUserId,
   createCart,
   createCartNoUser,
@@ -139,6 +140,27 @@ export const useCartStore = defineStore('cart', () => {
       }
     });
   }
+  async function getGuestCartItems(cartId: string) {
+    await getCart(cartId).then((res: Response) => {
+      if (res.status === 200) {
+        console.log('guest cart found in db');
+        return res.json().then((data) => {
+          rawItems.value = data.cart.Cart_items.map((item: CartItemResponse) => {
+            return {
+              postgresId: item.ProductId,
+              name: item.Product.name,
+              description: item.Product.description,
+              size: item.Product["size"] ? item.Product["size"] : 'N/A',
+              price: item.Product.price.toFixed(2),
+              quantity: item.quantity,
+            } as unknown as CartItem;
+          });
+        });
+      } else {
+        console.error('guest cart not found in db');
+      }
+    });
+  }
   async function addToCart(item: CartItem) {
     console.log('>>> adding item to cart');
     if(!id.value) {
@@ -211,6 +233,7 @@ export const useCartStore = defineStore('cart', () => {
     removeFromCart,
     itemTotalAmount,
     mergeOrLinkCart,
+    getGuestCartItems,
     $reset,
   }
 });


### PR DESCRIPTION
## Backend :

- Fix : le panier disparaissait quand on rafraichit la page, du au fait que les données récupérées sont stockés dans un store.
Le fix se fait au niveau de la modal du panier. Lorsque le panier est vide au `onMounted()`, on vérifie la présence d'un `cartId`, sinon on check si le gars est co et on récup le panier en bdd